### PR TITLE
Remove unused config.js script

### DIFF
--- a/creator-ar.html
+++ b/creator-ar.html
@@ -8,7 +8,6 @@
   <link rel="stylesheet" href="styles/gallery.css" />
 
   <script src="js/env.js"></script>
-  <script src="js/config.js"></script>
 
   <!-- ✅ Meta Tags Injection Script -->
   <script type="module">

--- a/creator-profiles-ar.html
+++ b/creator-profiles-ar.html
@@ -35,7 +35,6 @@
   </footer>
 
   <script src="js/env.js"></script>
-  <script src="js/config.js"></script>
   <script type="module" src="js/creators-list.js"></script>
 </body>
 </html>

--- a/creator-profiles.html
+++ b/creator-profiles.html
@@ -35,7 +35,6 @@
   </footer>
 
   <script src="js/env.js"></script>
-  <script src="js/config.js"></script>
   <script type="module" src="js/creators-list.js"></script>
 </body>
 </html>

--- a/creator.html
+++ b/creator.html
@@ -8,7 +8,6 @@
   <link rel="stylesheet" href="styles/gallery.css" />
 
   <script src="js/env.js"></script>
-  <script src="js/config.js"></script>
 
   <!-- ✅ Meta Tags Injection Script -->
   <script type="module">

--- a/gallery-ar.html
+++ b/gallery-ar.html
@@ -8,7 +8,6 @@
   <link rel="stylesheet" href="styles/gallery.css">
   <link rel="icon" href="favicon.ico">
   <script src="js/env.js"></script>
-  <script src="js/config.js"></script>
   <script defer src="js/main.js"></script>
   <script type="module" src="js/gallery.js"></script>
 </head>

--- a/gallery.html
+++ b/gallery.html
@@ -8,7 +8,6 @@
   <link rel="stylesheet" href="styles/gallery.css">
   <link rel="icon" href="favicon.ico">
   <script src="js/env.js"></script>
-  <script src="js/config.js"></script>
   <script defer src="js/main.js"></script>
   <script type="module" src="js/gallery.js"></script>
 </head>

--- a/index-ar.html
+++ b/index-ar.html
@@ -12,8 +12,6 @@
 
 
   <!-- تحميل config.js أولاً -->
-  <script src="js/config.js"></script>
-
   <!-- ثم تحميل main.js -->
   <script defer src="js/main.js"></script>
 </head>

--- a/index.html
+++ b/index.html
@@ -12,7 +12,6 @@
   <script src="js/env.js"></script>
   
   <!-- موجود سابقًا -->
-  <script src="js/config.js"></script>
   <script defer src="js/main.js"></script>
 </head>
   


### PR DESCRIPTION
## Summary
- strip `js/config.js` from all HTML pages since `env.js` already defines Supabase configuration

## Testing
- `grep -R "config.js" -n`

------
https://chatgpt.com/codex/tasks/task_e_68403536fcb8832286936fa260c0fb26