### PR TITLE
Add password-protected admin approvals

### DIFF
--- a/admin/admin.html
+++ b/admin/admin.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>Admin – Review Submissions</title>
+  <title>Admin – Approvals</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="stylesheet" href="../styles/main.css">
   <script src="../js/env.js"></script>
@@ -10,103 +10,27 @@
 <body>
   <main class="container">
     <h1>📋 Pending Submissions</h1>
-    <table id="submissions-table" border="1" cellpadding="8" style="width:100%;margin-top:1rem;">
-      <thead>
-        <tr>
-          <th>Creator</th>
-          <th>Type</th>
-          <th>Title</th>
-          <th>Link</th>
-          <th>Description</th>
-          <th>Action</th>
-        </tr>
-      </thead>
-      <tbody></tbody>
-    </table>
+    <div id="login-box" class="glass" style="margin-top:1rem;padding:1rem;">
+      <input type="password" id="admin-password" placeholder="Password">
+      <button id="login-btn">Enter</button>
+    </div>
+    <div id="approval-panel" style="display:none;margin-top:1.5rem;">
+      <table id="submissions-table" class="glass" style="width:100%;">
+        <thead>
+          <tr>
+            <th>Creator</th>
+            <th>Type</th>
+            <th>Title</th>
+            <th>Image</th>
+            <th>Description</th>
+            <th>Action</th>
+          </tr>
+        </thead>
+        <tbody></tbody>
+      </table>
+    </div>
   </main>
 
-  <script type="module">
-    import { createClient } from 'https://cdn.jsdelivr.net/npm/@supabase/supabase-js/+esm';
-
-    const supabase = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
-    const tableBody = document.querySelector('#submissions-table tbody');
-
-    // 👇 هذه الحماية مستقبلًا عندما تفعل Supabase Auth (غير مفعلة الآن)
-    /*
-    const { data: { user } } = await supabase.auth.getUser();
-    if (!user || user.email !== "admin@ramallah.ai") {
-      alert("Access denied!");
-      window.location.href = "/";
-    }
-    */
-
-    async function fetchPending() {
-      const { data, error } = await supabase
-        .from('submissions')
-        .select('*')
-        .eq('status', 'pending');
-
-      if (error) {
-        alert('❌ Failed to load submissions');
-        return;
-      }
-
-      tableBody.innerHTML = '';
-      data.forEach(row => {
-        const tr = document.createElement('tr');
-
-        const tdCreator = document.createElement('td');
-        tdCreator.textContent = row.creator_name || '-';
-        tr.appendChild(tdCreator);
-
-        const tdType = document.createElement('td');
-        tdType.textContent = row.type;
-        tr.appendChild(tdType);
-
-        const tdTitle = document.createElement('td');
-        tdTitle.textContent = row.title_en || row.title_ar || '-';
-        tr.appendChild(tdTitle);
-
-        const tdLink = document.createElement('td');
-        const link = document.createElement('a');
-        link.href = row.link;
-        link.target = '_blank';
-        link.textContent = '🔗 View';
-        tdLink.appendChild(link);
-        tr.appendChild(tdLink);
-
-        const tdDesc = document.createElement('td');
-        tdDesc.textContent = row.desc_en || row.desc_ar || '-';
-        tr.appendChild(tdDesc);
-
-        const tdAction = document.createElement('td');
-        const btn = document.createElement('button');
-        btn.dataset.id = row.id;
-        btn.textContent = 'Approve ✅';
-        tdAction.appendChild(btn);
-        tr.appendChild(tdAction);
-
-        tableBody.appendChild(tr);
-      });
-    }
-
-    tableBody.addEventListener('click', async (e) => {
-      if (e.target.tagName === 'BUTTON') {
-        const id = e.target.dataset.id;
-        const { error } = await supabase
-          .from('submissions')
-          .update({ status: 'approved' })
-          .eq('id', id);
-
-        if (error) {
-          alert('❌ Failed to approve');
-        } else {
-          e.target.closest('tr').remove();
-        }
-      }
-    });
-
-    fetchPending();
-  </script>
+  <script type="module" src="admin.js"></script>
 </body>
 </html>

--- a/admin/admin.js
+++ b/admin/admin.js
@@ -1,0 +1,96 @@
+import { createClient } from 'https://cdn.jsdelivr.net/npm/@supabase/supabase-js/+esm';
+
+const PASSWORD = 'ramallah2025';
+const supabase = createClient(window.SUPABASE_URL, window.SUPABASE_ANON_KEY);
+
+const loginBox = document.getElementById('login-box');
+const approvalPanel = document.getElementById('approval-panel');
+const tableBody = document.querySelector('#submissions-table tbody');
+
+document.getElementById('login-btn').addEventListener('click', () => {
+  const val = document.getElementById('admin-password').value.trim();
+  if (val === PASSWORD) {
+    loginBox.style.display = 'none';
+    approvalPanel.style.display = 'block';
+    fetchPending();
+  } else {
+    alert('Incorrect password');
+  }
+});
+
+async function fetchPending() {
+  const { data, error } = await supabase
+    .from('submissions')
+    .select('*')
+    .eq('approved', false);
+
+  if (error) {
+    alert('❌ Failed to load submissions');
+    return;
+  }
+
+  tableBody.innerHTML = '';
+  data.forEach((row) => {
+    const tr = document.createElement('tr');
+
+    const tdCreator = document.createElement('td');
+    tdCreator.textContent = row.creator_name || row.creator || '-';
+    tr.appendChild(tdCreator);
+
+    const tdType = document.createElement('td');
+    tdType.textContent = row.type || '-';
+    tr.appendChild(tdType);
+
+    const tdTitle = document.createElement('td');
+    tdTitle.textContent = row.title_en || row.title_ar || row.title || '-';
+    tr.appendChild(tdTitle);
+
+    const tdThumb = document.createElement('td');
+    if (row.thumb || row.link) {
+      const img = document.createElement('img');
+      img.src = row.thumb || row.link;
+      img.alt = '';
+      img.style.width = '80px';
+      img.style.borderRadius = '8px';
+      tdThumb.appendChild(img);
+    } else {
+      tdThumb.textContent = '-';
+    }
+    tr.appendChild(tdThumb);
+
+    const tdDesc = document.createElement('td');
+    tdDesc.textContent = row.desc_en || row.desc_ar || '-';
+    tr.appendChild(tdDesc);
+
+    const tdAction = document.createElement('td');
+    const btn = document.createElement('button');
+    btn.dataset.id = row.id;
+    btn.textContent = 'Approve ✅';
+    btn.className = 'approve-btn';
+    tdAction.appendChild(btn);
+    const feedback = document.createElement('div');
+    feedback.className = 'feedback';
+    tdAction.appendChild(feedback);
+    tr.appendChild(tdAction);
+
+    tableBody.appendChild(tr);
+  });
+}
+
+tableBody.addEventListener('click', async (e) => {
+  if (e.target.matches('button.approve-btn')) {
+    const id = e.target.dataset.id;
+    const feedback = e.target.nextElementSibling;
+    const { error } = await supabase
+      .from('submissions')
+      .update({ approved: true })
+      .eq('id', id);
+
+    if (error) {
+      feedback.textContent = 'Error!';
+    } else {
+      feedback.textContent = 'Approved!';
+      setTimeout(() => e.target.closest('tr').remove(), 500);
+    }
+  }
+});

--- a/styles/main.css
+++ b/styles/main.css
@@ -150,3 +150,45 @@ html[dir="rtl"] .like-box {
   from {opacity:0;transform:translateY(30px);}
   to {opacity:1;transform:none;}
 }
+
+#login-box {
+  display: flex;
+  gap: 0.5rem;
+}
+
+#login-box input {
+  padding: 0.5rem;
+  border-radius: var(--radius);
+  border: 1px solid #444;
+}
+
+#login-box button,
+.approve-btn {
+  background: var(--accent);
+  color: #fff;
+  border: none;
+  padding: 0.4rem 0.9rem;
+  border-radius: var(--radius);
+  cursor: pointer;
+}
+
+#login-box button:hover,
+.approve-btn:hover {
+  background: var(--accent-dark);
+}
+
+#submissions-table {
+  border-collapse: collapse;
+  margin-top: 1rem;
+}
+
+#submissions-table th,
+#submissions-table td {
+  padding: 0.6rem;
+  border-bottom: 1px solid rgba(255,255,255,0.1);
+}
+
+.feedback {
+  margin-top: 0.3rem;
+  font-size: 0.85rem;
+}


### PR DESCRIPTION
## Summary
- implement simple login in `admin/admin.html`
- create `admin/admin.js` to load pending submissions and handle approvals
- style login box, table and buttons in `styles/main.css`

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68407c9a0e4c832296910b31d25c2729