### PR TITLE
Add success stories and blog interactions

### DIFF
--- a/blog-ar.html
+++ b/blog-ar.html
@@ -1,9 +1,54 @@
-<!DOCTYPE html><html lang="ar" dir="rtl"><head><title>مدونة Ramallah.ai</title><meta charset="UTF-8">
-<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
-<link rel="stylesheet" href="styles/main.css">
-<script defer src="js/main.js"></script>
-<link rel="icon" href="favicon.ico"></head><body><header class="navbar navbar-dark"><div class="navbar-container">
-<a class="logo" href="index-ar.html">Ramallah.ai</a>
-<button id="nav-hamburger" class="navbar-hamburger" aria-label="Menu"><span></span><span></span><span></span></button>
-<nav class="navbar-links" id="navbar-links"><a href="index-ar.html">الرئيسية</a><a href="gallery-ar.html">المعرض</a><a href="about-ar.html">من نحن</a><a href="blog-ar.html" aria-current="page">مدونة</a><a href="index-ar.html#submit">أرسل عملك</a><a href="creator-profiles-ar.html">المبدعون</a><a href="contact-ar.html">اتصل بنا</a></nav><a href="index.html" class="lang-toggle" lang="en">English</a></div></header>
-<main class="container"><h1>مدونة Ramallah.ai</h1><article><h2>مرحباً</h2><p>مقال تمهيدي.</p></article></main><footer class="footer glass kufiyya-bg"><small>©2025 Ramallah.ai</small></footer></body></html>
+<!DOCTYPE html>
+<html lang="ar" dir="rtl">
+<head>
+  <title>مدونة Ramallah.ai</title>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+  <link rel="stylesheet" href="styles/main.css">
+  <script defer src="js/main.js"></script>
+  <script defer src="js/blog.js"></script>
+  <link rel="icon" href="favicon.ico">
+</head>
+<body>
+<header class="navbar navbar-dark"><div class="navbar-container"><a class="logo" href="index-ar.html">Ramallah.ai</a><button id="nav-hamburger" class="navbar-hamburger" aria-label="Menu"><span></span><span></span><span></span></button><nav class="navbar-links" id="navbar-links"><a href="index-ar.html">الرئيسية</a><a href="gallery-ar.html">المعرض</a><a href="about-ar.html">من نحن</a><a href="blog-ar.html" aria-current="page">مدونة</a><a href="index-ar.html#submit">أرسل عملك</a><a href="creator-profiles-ar.html">المبدعون</a><a href="contact-ar.html">اتصل بنا</a></nav><a href="blog.html" class="lang-toggle" lang="en">English</a></div></header>
+<main class="container">
+  <h1>مدونة Ramallah.ai</h1>
+  <p class="blog-intro">الذكاء الاصطناعي وفلسطين: قصص إبداعية، دروس، وكواليس من رحلات المبدعين</p>
+  <div class="tag-filter">
+    <button data-tag="" class="active">الكل</button>
+    <button data-tag="History">تاريخ</button>
+    <button data-tag="Technique">تقنية</button>
+    <button data-tag="Behind">خلف الكواليس</button>
+  </div>
+  <article data-id="1" data-tags="History">
+    <h2>مرحباً</h2>
+    <p>مقال تمهيدي.</p>
+    <div class="like-box"><button class="like-btn cta-btn">👍 إعجاب</button> <span class="like-count">0</span></div>
+    <div class="comment-box">
+      <form class="comment-form"><input name="name" placeholder="الاسم" required><textarea name="comment" placeholder="تعليق" required></textarea><button type="submit">إرسال</button></form>
+      <ul class="comments-list"></ul>
+    </div>
+  </article>
+  <article data-id="2" data-tags="Technique,Behind">
+    <h2>عملية الإبداع</h2>
+    <p>نص تجريبي يشرح كيف نجرب الأدوات.</p>
+    <div class="like-box"><button class="like-btn cta-btn">👍 إعجاب</button> <span class="like-count">0</span></div>
+    <div class="comment-box">
+      <form class="comment-form"><input name="name" placeholder="الاسم" required><textarea name="comment" placeholder="تعليق" required></textarea><button type="submit">إرسال</button></form>
+      <ul class="comments-list"></ul>
+    </div>
+  </article>
+  <article data-id="3" data-tags="History">
+    <h2>إنجاز للمجتمع</h2>
+    <p>ملاحظة قصيرة للاحتفال بآخر النجاحات.</p>
+    <div class="like-box"><button class="like-btn cta-btn">👍 إعجاب</button> <span class="like-count">0</span></div>
+    <div class="comment-box">
+      <form class="comment-form"><input name="name" placeholder="الاسم" required><textarea name="comment" placeholder="تعليق" required></textarea><button type="submit">إرسال</button></form>
+      <ul class="comments-list"></ul>
+    </div>
+  </article>
+  <p style="margin-top:2rem;"><a href="contact-ar.html" class="cta-btn">تريد مشاركة تجربتك؟ أرسل تدوينة.</a></p>
+</main>
+<footer class="footer glass kufiyya-bg"><small>©2025 Ramallah.ai</small></footer>
+</body>
+</html>

--- a/blog.html
+++ b/blog.html
@@ -1,21 +1,55 @@
-<!DOCTYPE html><html lang="en"><head><title>Blog – Ramallah.ai</title><meta charset="UTF-8">
-<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
-<link rel="stylesheet" href="styles/main.css">
-<script defer src="js/main.js"></script>
-<link rel="icon" href="favicon.ico">
-<meta name="description" content="Insights and updates from the Ramallah.ai team on AI creativity in Palestine.">
-<meta property="og:title" content="Blog – Ramallah.ai">
-<meta property="og:description" content="Read the latest articles and announcements about AI creativity in Palestine.">
-<meta property="og:image" content="images/wa.link_lg02ac.png">
-<meta property="og:url" content="https://ramallah.ai/blog.html">
-<meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="Blog – Ramallah.ai">
-<meta name="twitter:description" content="Read the latest articles and announcements about AI creativity in Palestine.">
-<meta name="twitter:image" content="images/wa.link_lg02ac.png">
-<link rel="canonical" href="https://ramallah.ai/blog.html">
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <title>Blog – Ramallah.ai</title>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+  <link rel="stylesheet" href="styles/main.css">
+  <script defer src="js/main.js"></script>
+  <script defer src="js/blog.js"></script>
+  <link rel="icon" href="favicon.ico">
+  <meta name="description" content="Insights and updates from the Ramallah.ai team on AI creativity in Palestine.">
 </head>
-<body><header class="navbar navbar-dark"><div class="navbar-container">
-<a class="logo" href="index.html">Ramallah.ai</a>
-<button id="nav-hamburger" class="navbar-hamburger" aria-label="Menu"><span></span><span></span><span></span></button>
-<nav class="navbar-links" id="navbar-links"><a href="index.html">Home</a><a href="gallery.html">Gallery</a><a href="about.html">About</a><a href="blog.html" aria-current="page">Blog</a><a href="index.html#submit">Submit</a><a href="creator-profiles.html">Creators</a><a href="contact.html">Contact</a></nav><a href="index-ar.html" class="lang-toggle" lang="ar">العربية</a></div></header>
-<main class="container"><h1>Ramallah.ai Blog</h1><article><h2>Welcome</h2><p>Intro post.</p></article></main><footer class="footer glass kufiyya-bg"><small>©2025 Ramallah.ai</small></footer></body></html>
+<body>
+<header class="navbar navbar-dark"><div class="navbar-container"><a class="logo" href="index.html">Ramallah.ai</a><button id="nav-hamburger" class="navbar-hamburger" aria-label="Menu"><span></span><span></span><span></span></button><nav class="navbar-links" id="navbar-links"><a href="index.html">Home</a><a href="gallery.html">Gallery</a><a href="about.html">About</a><a href="blog.html" aria-current="page">Blog</a><a href="index.html#submit">Submit</a><a href="creator-profiles.html">Creators</a><a href="contact.html">Contact</a></nav><a href="blog-ar.html" class="lang-toggle" lang="ar">العربية</a></div></header>
+<main class="container">
+  <h1>Ramallah.ai Blog</h1>
+  <p class="blog-intro">AI &amp; Palestine: Creative stories, tutorials, behind-the-scenes journeys of creators using AI</p>
+  <div class="tag-filter">
+    <button data-tag="" class="active">All</button>
+    <button data-tag="History">History</button>
+    <button data-tag="Technique">Technique</button>
+    <button data-tag="Behind">Behind the Scenes</button>
+  </div>
+  <article data-id="1" data-tags="History">
+    <h2>Welcome</h2>
+    <p>Intro post.</p>
+    <div class="like-box"><button class="like-btn cta-btn">👍 Like</button> <span class="like-count">0</span></div>
+    <div class="comment-box">
+      <form class="comment-form"><input name="name" placeholder="Name" required><textarea name="comment" placeholder="Comment" required></textarea><button type="submit">Send</button></form>
+      <ul class="comments-list"></ul>
+    </div>
+  </article>
+  <article data-id="2" data-tags="Technique,Behind">
+    <h2>Creative Process</h2>
+    <p>Placeholder content describing how we experiment with tools.</p>
+    <div class="like-box"><button class="like-btn cta-btn">👍 Like</button> <span class="like-count">0</span></div>
+    <div class="comment-box">
+      <form class="comment-form"><input name="name" placeholder="Name" required><textarea name="comment" placeholder="Comment" required></textarea><button type="submit">Send</button></form>
+      <ul class="comments-list"></ul>
+    </div>
+  </article>
+  <article data-id="3" data-tags="History">
+    <h2>Community Milestone</h2>
+    <p>A short note celebrating our recent achievements.</p>
+    <div class="like-box"><button class="like-btn cta-btn">👍 Like</button> <span class="like-count">0</span></div>
+    <div class="comment-box">
+      <form class="comment-form"><input name="name" placeholder="Name" required><textarea name="comment" placeholder="Comment" required></textarea><button type="submit">Send</button></form>
+      <ul class="comments-list"></ul>
+    </div>
+  </article>
+  <p style="margin-top:2rem;"><a href="contact.html" class="cta-btn">Want to share your journey? Submit a blog post.</a></p>
+</main>
+<footer class="footer glass kufiyya-bg"><small>©2025 Ramallah.ai</small></footer>
+</body>
+</html>

--- a/index-ar.html
+++ b/index-ar.html
@@ -55,16 +55,21 @@
   <section class="success-stories">
     <h2>قصص نجاح</h2>
     <div class="story-carousel">
-      <article class="story-card">
+      <a class="story-card" href="story1-ar.html">
         <img src="images/success/laila-work.png" alt="لقطة من فيلم ليلى القصير">
         <h3>فيلم ليلى</h3>
         <p>باستخدام Stable Diffusion وRunway.</p>
-      </article>
-      <article class="story-card">
+      </a>
+      <a class="story-card" href="story2-ar.html">
         <img src="images/success/rami-work.png" alt="رامي يعمل على مقطوعة موسيقية بالذكاء الاصطناعي">
         <h3>مقطوعة رامي</h3>
         <p>تأليف AI في Ableton.</p>
-      </article>
+      </a>
+      <a class="story-card" href="story3-ar.html">
+        <img src="images/gallery/gallery-art.png" alt="عمل فني">
+        <h3>مشروع ملهم آخر</h3>
+        <p>استكشاف تقنيات الذكاء الاصطناعي.</p>
+      </a>
     </div>
   </section>
 

--- a/index.html
+++ b/index.html
@@ -58,16 +58,21 @@
   <section class="success-stories">
     <h2>Success Stories</h2>
     <div class="story-carousel">
-      <article class="story-card">
+      <a class="story-card" href="story1.html">
         <img src="images/success/laila-work.png" alt="Still from Laila's animated short film">
         <h3>Laila’s animated short</h3>
         <p>Created with Stable Diffusion & Runway.</p>
-      </article>
-      <article class="story-card">
+      </a>
+      <a class="story-card" href="story2.html">
         <img src="images/success/rami-work.png" alt="Rami creating music with AI tools">
         <h3>Rami’s generative track</h3>
         <p>AI‑assisted composition in Ableton.</p>
-      </article>
+      </a>
+      <a class="story-card" href="story3.html">
+        <img src="images/gallery/gallery-art.png" alt="Placeholder art">
+        <h3>Another inspiring project</h3>
+        <p>Exploring creative AI techniques.</p>
+      </a>
     </div>
   </section>
 

--- a/js/blog.js
+++ b/js/blog.js
@@ -1,0 +1,63 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const isArabic = document.documentElement.lang === 'ar';
+
+  // Tag filtering
+  const buttons = document.querySelectorAll('.tag-filter button');
+  buttons.forEach(btn => {
+    btn.addEventListener('click', () => {
+      buttons.forEach(b => b.classList.remove('active'));
+      btn.classList.add('active');
+      const tag = btn.dataset.tag || '';
+      document.querySelectorAll('article[data-tags]').forEach(article => {
+        const tags = article.dataset.tags.split(',');
+        if (!tag || tags.includes(tag)) {
+          article.style.display = '';
+        } else {
+          article.style.display = 'none';
+        }
+      });
+    });
+  });
+
+  // Likes and comments
+  document.querySelectorAll('article[data-id]').forEach(article => {
+    const id = article.dataset.id;
+    const likeBtn = article.querySelector('.like-btn');
+    const likeCount = article.querySelector('.like-count');
+    const commentsList = article.querySelector('.comments-list');
+    const form = article.querySelector('.comment-form');
+
+    // Likes
+    let count = parseInt(localStorage.getItem(`blog_like_${id}`)) || 0;
+    likeCount.textContent = count;
+    likeBtn.addEventListener('click', () => {
+      count++;
+      localStorage.setItem(`blog_like_${id}`, count);
+      likeCount.textContent = count;
+    });
+
+    // Comments
+    const loadComments = () => {
+      const saved = JSON.parse(localStorage.getItem(`blog_comments_${id}`) || '[]');
+      commentsList.innerHTML = '';
+      saved.forEach(c => {
+        const li = document.createElement('li');
+        li.textContent = `${c.name}: ${c.text}`;
+        commentsList.appendChild(li);
+      });
+    };
+    loadComments();
+
+    form.addEventListener('submit', e => {
+      e.preventDefault();
+      const name = form.name.value.trim();
+      const text = form.comment.value.trim();
+      if (!name || !text) return;
+      const saved = JSON.parse(localStorage.getItem(`blog_comments_${id}`) || '[]');
+      saved.push({name, text});
+      localStorage.setItem(`blog_comments_${id}`, JSON.stringify(saved));
+      form.reset();
+      loadComments();
+    });
+  });
+});

--- a/story1-ar.html
+++ b/story1-ar.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="ar" dir="rtl">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+  <title>الفيلم القصير لليلى – Ramallah.ai</title>
+  <meta name="description" content="كيف استخدمت ليلى أدوات الذكاء الاصطناعي لصناعة فيلم قصير.">
+  <link rel="stylesheet" href="styles/main.css">
+  <script defer src="js/main.js"></script>
+</head>
+<body>
+<header class="navbar navbar-dark"><div class="navbar-container"><a class="logo" href="index-ar.html">Ramallah.ai</a><button id="nav-hamburger" class="navbar-hamburger" aria-label="Menu"><span></span><span></span><span></span></button><nav class="navbar-links" id="navbar-links"><a href="index-ar.html">الرئيسية</a><a href="gallery-ar.html">المعرض</a><a href="about-ar.html">من نحن</a><a href="blog-ar.html">مدونة</a><a href="index-ar.html#submit">أرسل عملك</a><a href="creator-profiles-ar.html">المبدعون</a><a href="contact-ar.html">اتصل بنا</a></nav><a href="index.html" class="lang-toggle" lang="en">English</a></div></header>
+<main class="container">
+  <h1>الفيلم القصير لليلى</h1>
+  <p>باستخدام Stable Diffusion و Runway.</p>
+  <p>هذه قصة توضح كيف جمعت ليلى بين توليد الصور وأدوات الفيديو لإنتاج فيلم قصير.</p>
+  <p class="creator-details">بواسطة <b>ليلى</b></p>
+</main>
+<footer class="footer glass kufiyya-bg"><small>©2025 Ramallah.ai</small></footer>
+</body>
+</html>

--- a/story1.html
+++ b/story1.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+  <title>Laila’s Animated Short – Ramallah.ai</title>
+  <meta name="description" content="How Laila used AI tools to craft an animated short film.">
+  <link rel="stylesheet" href="styles/main.css">
+  <script defer src="js/main.js"></script>
+</head>
+<body>
+<header class="navbar navbar-dark"><div class="navbar-container"><a class="logo" href="index.html">Ramallah.ai</a><button id="nav-hamburger" class="navbar-hamburger" aria-label="Menu"><span></span><span></span><span></span></button><nav class="navbar-links" id="navbar-links"><a href="index.html">Home</a><a href="gallery.html">Gallery</a><a href="about.html">About</a><a href="blog.html">Blog</a><a href="index.html#submit">Submit</a><a href="creator-profiles.html">Creators</a><a href="contact.html">Contact</a></nav><a href="index-ar.html" class="lang-toggle" lang="ar">العربية</a></div></header>
+<main class="container">
+  <h1>Laila’s Animated Short</h1>
+  <p>Created with Stable Diffusion and Runway.</p>
+  <p>This placeholder story details how Laila combined AI image generation with video tools to produce a short film.</p>
+  <p class="creator-details">By <b>Laila</b></p>
+</main>
+<footer class="footer glass kufiyya-bg"><small>©2025 Ramallah.ai</small></footer>
+</body>
+</html>

--- a/story2-ar.html
+++ b/story2-ar.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="ar" dir="rtl">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+  <title>مقطوعة رامي – Ramallah.ai</title>
+  <meta name="description" content="تجربة رامي في إنتاج الموسيقى بالذكاء الاصطناعي.">
+  <link rel="stylesheet" href="styles/main.css">
+  <script defer src="js/main.js"></script>
+</head>
+<body>
+<header class="navbar navbar-dark"><div class="navbar-container"><a class="logo" href="index-ar.html">Ramallah.ai</a><button id="nav-hamburger" class="navbar-hamburger" aria-label="Menu"><span></span><span></span><span></span></button><nav class="navbar-links" id="navbar-links"><a href="index-ar.html">الرئيسية</a><a href="gallery-ar.html">المعرض</a><a href="about-ar.html">من نحن</a><a href="blog-ar.html">مدونة</a><a href="index-ar.html#submit">أرسل عملك</a><a href="creator-profiles-ar.html">المبدعون</a><a href="contact-ar.html">اتصل بنا</a></nav><a href="index.html" class="lang-toggle" lang="en">English</a></div></header>
+<main class="container">
+  <h1>مقطوعة رامي</h1>
+  <p>تأليف بمساعدة الذكاء الاصطناعي في Ableton.</p>
+  <p>هذا نص تجريبي يشرح كيف استخدم رامي إضافات التعلم الآلي لإنتاج أغنية.</p>
+  <p class="creator-details">بواسطة <b>رامي</b></p>
+</main>
+<footer class="footer glass kufiyya-bg"><small>©2025 Ramallah.ai</small></footer>
+</body>
+</html>

--- a/story2.html
+++ b/story2.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+  <title>Rami’s Generative Track – Ramallah.ai</title>
+  <meta name="description" content="Rami experiments with AI-assisted music production.">
+  <link rel="stylesheet" href="styles/main.css">
+  <script defer src="js/main.js"></script>
+</head>
+<body>
+<header class="navbar navbar-dark"><div class="navbar-container"><a class="logo" href="index.html">Ramallah.ai</a><button id="nav-hamburger" class="navbar-hamburger" aria-label="Menu"><span></span><span></span><span></span></button><nav class="navbar-links" id="navbar-links"><a href="index.html">Home</a><a href="gallery.html">Gallery</a><a href="about.html">About</a><a href="blog.html">Blog</a><a href="index.html#submit">Submit</a><a href="creator-profiles.html">Creators</a><a href="contact.html">Contact</a></nav><a href="index-ar.html" class="lang-toggle" lang="ar">العربية</a></div></header>
+<main class="container">
+  <h1>Rami’s Generative Track</h1>
+  <p>AI-assisted composition in Ableton.</p>
+  <p>This placeholder story explores how Rami produced a song using machine learning plugins.</p>
+  <p class="creator-details">By <b>Rami</b></p>
+</main>
+<footer class="footer glass kufiyya-bg"><small>©2025 Ramallah.ai</small></footer>
+</body>
+</html>

--- a/story3-ar.html
+++ b/story3-ar.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="ar" dir="rtl">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+  <title>قصة نجاح ثالثة – Ramallah.ai</title>
+  <meta name="description" content="مثال آخر لمشروع ملهم يستخدم الذكاء الاصطناعي.">
+  <link rel="stylesheet" href="styles/main.css">
+  <script defer src="js/main.js"></script>
+</head>
+<body>
+<header class="navbar navbar-dark"><div class="navbar-container"><a class="logo" href="index-ar.html">Ramallah.ai</a><button id="nav-hamburger" class="navbar-hamburger" aria-label="Menu"><span></span><span></span><span></span></button><nav class="navbar-links" id="navbar-links"><a href="index-ar.html">الرئيسية</a><a href="gallery-ar.html">المعرض</a><a href="about-ar.html">من نحن</a><a href="blog-ar.html">مدونة</a><a href="index-ar.html#submit">أرسل عملك</a><a href="creator-profiles-ar.html">المبدعون</a><a href="contact-ar.html">اتصل بنا</a></nav><a href="index.html" class="lang-toggle" lang="en">English</a></div></header>
+<main class="container">
+  <h1>قصة نجاح ثالثة</h1>
+  <p>هذه صفحة تجريبية لمشروع آخر ملهم يستخدم الذكاء الاصطناعي.</p>
+  <p class="creator-details">بواسطة <b>مجهول</b></p>
+</main>
+<footer class="footer glass kufiyya-bg"><small>©2025 Ramallah.ai</small></footer>
+</body>
+</html>

--- a/story3.html
+++ b/story3.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+  <title>Third Success Story – Ramallah.ai</title>
+  <meta name="description" content="Another example of creative AI use from Palestine.">
+  <link rel="stylesheet" href="styles/main.css">
+  <script defer src="js/main.js"></script>
+</head>
+<body>
+<header class="navbar navbar-dark"><div class="navbar-container"><a class="logo" href="index.html">Ramallah.ai</a><button id="nav-hamburger" class="navbar-hamburger" aria-label="Menu"><span></span><span></span><span></span></button><nav class="navbar-links" id="navbar-links"><a href="index.html">Home</a><a href="gallery.html">Gallery</a><a href="about.html">About</a><a href="blog.html">Blog</a><a href="index.html#submit">Submit</a><a href="creator-profiles.html">Creators</a><a href="contact.html">Contact</a></nav><a href="index-ar.html" class="lang-toggle" lang="ar">العربية</a></div></header>
+<main class="container">
+  <h1>Third Success Story</h1>
+  <p>This placeholder page showcases another inspiring project using AI.</p>
+  <p class="creator-details">By <b>Anonymous</b></p>
+</main>
+<footer class="footer glass kufiyya-bg"><small>©2025 Ramallah.ai</small></footer>
+</body>
+</html>

--- a/styles/main.css
+++ b/styles/main.css
@@ -258,3 +258,13 @@ html[dir="rtl"] .creator-socials a{
   margin-left:0.5rem;
   margin-right:0;
 }
+/* BLOG COMPONENTS */
+.tag-filter{display:flex;gap:.5rem;flex-wrap:wrap;margin-bottom:1rem}
+.tag-filter button{padding:.3rem .8rem;border-radius:var(--radius);border:1px solid #555;background:none;color:var(--text);cursor:pointer}
+.tag-filter button.active,.tag-filter button:hover{background:var(--accent);color:#fff;border-color:var(--accent)}
+.comment-box{margin-top:1rem}
+.comment-box form{display:flex;flex-direction:column;gap:.5rem;margin-top:.5rem}
+.comment-box input,.comment-box textarea{padding:.5rem;border-radius:var(--radius);border:1px solid #444;font-family:inherit}
+.comment-box button{align-self:flex-start;background:var(--accent);color:#fff;border:none;padding:.4rem .9rem;border-radius:var(--radius);cursor:pointer}
+.comment-box ul{list-style:none;padding-left:0;margin-top:.5rem}
+.comment-box li{margin-bottom:.5rem}

--- a/success-ar.html
+++ b/success-ar.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="ar" dir="rtl">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+  <title>قصص النجاح – Ramallah.ai</title>
+  <meta name="description" content="مشاريع ملهمة من مبدعين فلسطينيين يستخدمون الذكاء الاصطناعي.">
+  <link rel="stylesheet" href="styles/main.css">
+  <script defer src="js/main.js"></script>
+</head>
+<body>
+<header class="navbar navbar-dark"><div class="navbar-container"><a class="logo" href="index-ar.html">Ramallah.ai</a><button id="nav-hamburger" class="navbar-hamburger" aria-label="Menu"><span></span><span></span><span></span></button><nav class="navbar-links" id="navbar-links"><a href="index-ar.html">الرئيسية</a><a href="gallery-ar.html">المعرض</a><a href="about-ar.html">من نحن</a><a href="blog-ar.html">مدونة</a><a href="index-ar.html#submit">أرسل عملك</a><a href="creator-profiles-ar.html">المبدعون</a><a href="contact-ar.html">اتصل بنا</a></nav><a href="success.html" class="lang-toggle" lang="en">English</a></div></header>
+<main class="container">
+  <h1>قصص النجاح</h1>
+  <div class="story-carousel">
+    <a class="story-card" href="story1-ar.html"><img src="images/success/laila-work.png" alt="لقطة من فيلم ليلى"><h3>فيلم ليلى</h3><p>باستخدام Stable Diffusion و Runway.</p></a>
+    <a class="story-card" href="story2-ar.html"><img src="images/success/rami-work.png" alt="رامي يعمل على الموسيقى"><h3>مقطوعة رامي</h3><p>تأليف بالذكاء الاصطناعي في Ableton.</p></a>
+    <a class="story-card" href="story3-ar.html"><img src="images/gallery/gallery-art.png" alt="عمل فني"><h3>مشروع ملهم آخر</h3><p>استكشاف تقنيات الذكاء الاصطناعي.</p></a>
+  </div>
+</main>
+<footer class="footer glass kufiyya-bg"><small>©2025 Ramallah.ai</small></footer>
+</body>
+</html>

--- a/success.html
+++ b/success.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+  <title>Success Stories – Ramallah.ai</title>
+  <meta name="description" content="Inspiring projects from Palestinian creators using AI.">
+  <link rel="stylesheet" href="styles/main.css">
+  <script defer src="js/main.js"></script>
+</head>
+<body>
+<header class="navbar navbar-dark"><div class="navbar-container"><a class="logo" href="index.html">Ramallah.ai</a><button id="nav-hamburger" class="navbar-hamburger" aria-label="Menu"><span></span><span></span><span></span></button><nav class="navbar-links" id="navbar-links"><a href="index.html">Home</a><a href="gallery.html">Gallery</a><a href="about.html">About</a><a href="blog.html">Blog</a><a href="index.html#submit">Submit</a><a href="creator-profiles.html">Creators</a><a href="contact.html">Contact</a></nav><a href="success-ar.html" class="lang-toggle" lang="ar">العربية</a></div></header>
+<main class="container">
+  <h1>Success Stories</h1>
+  <div class="story-carousel">
+    <a class="story-card" href="story1.html"><img src="images/success/laila-work.png" alt="Still from Laila's film"><h3>Laila’s animated short</h3><p>Created with Stable Diffusion & Runway.</p></a>
+    <a class="story-card" href="story2.html"><img src="images/success/rami-work.png" alt="Rami working on music"><h3>Rami’s generative track</h3><p>AI‑assisted composition in Ableton.</p></a>
+    <a class="story-card" href="story3.html"><img src="images/gallery/gallery-art.png" alt="Placeholder art"><h3>Another inspiring project</h3><p>Exploring creative AI techniques.</p></a>
+  </div>
+</main>
+<footer class="footer glass kufiyya-bg"><small>©2025 Ramallah.ai</small></footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- make success stories on homepage link to new story pages
- add three placeholder story pages in English and Arabic
- add success listing pages for both languages
- expand blog section with tag filters, likes, comments, and CTA
- implement blog interactions JS and new CSS styles

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6840949042d08322bdba22a34d30aa6f