### PR TITLE
Add social share buttons

### DIFF
--- a/creator.html
+++ b/creator.html
@@ -151,7 +151,7 @@
         </div>
 
         <div class="share-box">
-          <button id="share-btn" class="cta-btn">🔗 Share</button>
+          <div id="share-buttons" class="share-icons"></div>
           <span id="share-status" style="font-size:0.9rem;color:gray;"></span>
         </div>
 
@@ -199,7 +199,7 @@
     });
 
     // Share logic
-    const shareBtn = document.getElementById('share-btn');
+    const shareContainer = document.getElementById('share-buttons');
     const shareStatus = document.getElementById('share-status');
     const shareTitle = `${data.name} – Ramallah.ai`;
     const shareText = isArabic
@@ -207,19 +207,54 @@
       : `Meet ${data.name} on Ramallah.ai`;
     const shareUrl = window.location.href;
 
-    shareBtn.addEventListener('click', async () => {
-      try {
-        await navigator.clipboard.writeText(shareUrl);
-        shareStatus.textContent = isArabic
-          ? '📋 تم نسخ الرابط'
-          : '📋 Link copied!';
-        setTimeout(() => (shareStatus.textContent = ''), 2000);
-      } catch {
-        shareStatus.textContent = isArabic
-          ? '❌ لم يتم نسخ الرابط'
-          : '❌ Failed to copy link.';
-      }
-    });
+    const isMobileShare = navigator.share && window.innerWidth < 768;
+
+    if (isMobileShare) {
+      const btn = document.createElement('button');
+      btn.textContent = '🔗';
+      btn.title = isArabic ? 'مشاركة' : 'Share';
+      btn.addEventListener('click', () => {
+        navigator.share({ title: shareTitle, text: shareText, url: shareUrl });
+      });
+      shareContainer.appendChild(btn);
+    } else {
+      const openWin = (u) => window.open(u, '_blank');
+      const wa = document.createElement('button');
+      wa.textContent = '💬';
+      wa.title = 'WhatsApp';
+      wa.addEventListener('click', () =>
+        openWin(`https://wa.me/?text=${encodeURIComponent(shareText + ' ' + shareUrl)}`)
+      );
+      const fb = document.createElement('button');
+      fb.textContent = '📘';
+      fb.title = 'Facebook';
+      fb.addEventListener('click', () =>
+        openWin(`https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(shareUrl)}`)
+      );
+      const tw = document.createElement('button');
+      tw.textContent = '🐦';
+      tw.title = 'X';
+      tw.addEventListener('click', () =>
+        openWin(`https://twitter.com/intent/tweet?url=${encodeURIComponent(shareUrl)}&text=${encodeURIComponent(shareText)}`)
+      );
+      const copy = document.createElement('button');
+      copy.textContent = '🔗';
+      copy.title = isArabic ? 'نسخ الرابط' : 'Copy link';
+      copy.addEventListener('click', async () => {
+        try {
+          await navigator.clipboard.writeText(shareUrl);
+          shareStatus.textContent = isArabic
+            ? '📋 تم نسخ الرابط'
+            : '📋 Link copied!';
+          setTimeout(() => (shareStatus.textContent = ''), 2000);
+        } catch {
+          shareStatus.textContent = isArabic
+            ? '❌ لم يتم نسخ الرابط'
+            : '❌ Failed to copy link.';
+        }
+      });
+      [wa, fb, tw, copy].forEach((b) => shareContainer.appendChild(b));
+    }
   })();
 }
 </script>

--- a/js/gallery.js
+++ b/js/gallery.js
@@ -27,6 +27,53 @@ const params = new URLSearchParams(window.location.search);
 const creatorParam = (params.get('creator') || '').toLowerCase();
 const isArabic = document.documentElement.lang === 'ar';
 
+function createShareButtons(url, text) {
+  const container = document.createElement('div');
+  container.className = 'share-icons';
+  const isMobileShare = navigator.share && window.innerWidth < 768;
+  if (isMobileShare) {
+    const btn = document.createElement('button');
+    btn.textContent = '🔗';
+    btn.title = isArabic ? 'مشاركة' : 'Share';
+    btn.addEventListener('click', () => {
+      navigator.share({ title: text, text, url }).catch(() => {});
+    });
+    container.appendChild(btn);
+  } else {
+    const openWin = (u) => window.open(u, '_blank');
+    const wa = document.createElement('button');
+    wa.textContent = '💬';
+    wa.title = 'WhatsApp';
+    wa.addEventListener('click', () =>
+      openWin(`https://wa.me/?text=${encodeURIComponent(text + ' ' + url)}`)
+    );
+    const fb = document.createElement('button');
+    fb.textContent = '📘';
+    fb.title = 'Facebook';
+    fb.addEventListener('click', () =>
+      openWin(`https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(url)}`)
+    );
+    const tw = document.createElement('button');
+    tw.textContent = '🐦';
+    tw.title = 'X';
+    tw.addEventListener('click', () =>
+      openWin(`https://twitter.com/intent/tweet?url=${encodeURIComponent(url)}&text=${encodeURIComponent(text)}`)
+    );
+    const copy = document.createElement('button');
+    copy.textContent = '🔗';
+    copy.title = isArabic ? 'نسخ الرابط' : 'Copy link';
+    copy.addEventListener('click', async () => {
+      try {
+        await navigator.clipboard.writeText(url);
+        copy.textContent = '✅';
+        setTimeout(() => (copy.textContent = '🔗'), 1500);
+      } catch {}
+    });
+    [wa, fb, tw, copy].forEach((b) => container.appendChild(b));
+  }
+  return container;
+}
+
 async function fetchCreators() {
   const { data, error } = await supabase.from('creators').select('name,slug');
   if (!error && data) {
@@ -162,6 +209,9 @@ function renderFiltered(reset = false) {
       link.textContent = '🔗 View Work';
       card.appendChild(link);
     }
+
+    const share = createShareButtons(item.link || window.location.href, item.title || '');
+    card.appendChild(share);
 
     container.appendChild(card);
   });

--- a/styles/gallery.css
+++ b/styles/gallery.css
@@ -84,6 +84,8 @@
   text-decoration: underline;
 }
 
+.gallery-card .share-icons{margin-top:.5rem}
+
 
 .filter-bar {
   display: flex;

--- a/styles/main.css
+++ b/styles/main.css
@@ -258,6 +258,9 @@ html[dir="rtl"] .creator-socials a{
   margin-left:0.5rem;
   margin-right:0;
 }
+.share-icons{display:flex;gap:.5rem;margin-top:.5rem;align-items:center}
+.share-icons button{background:none;border:none;cursor:pointer;font-size:1.2rem;padding:.2rem}
+.share-icons button:hover{opacity:.7}
 /* BLOG COMPONENTS */
 .tag-filter{display:flex;gap:.5rem;flex-wrap:wrap;margin-bottom:1rem}
 .tag-filter button{padding:.3rem .8rem;border-radius:var(--radius);border:1px solid #555;background:none;color:var(--text);cursor:pointer}


### PR DESCRIPTION
## Summary
- add `.share-icons` styles
- show share buttons on creator page using emojis and native share on mobile
- create share buttons for each gallery card with copy-link fallback

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68414778e6cc83229c42ee046e58d35d