### PR TITLE
Improve like system and gallery sorting

### DIFF
--- a/creator.html
+++ b/creator.html
@@ -106,6 +106,13 @@
   import { createClient } from 'https://cdn.jsdelivr.net/npm/@supabase/supabase-js/+esm';
 
   const supabase = createClient(window.SUPABASE_URL, window.SUPABASE_ANON_KEY);
+  let visitorIP = '';
+  (async () => {
+    try {
+      const res = await fetch('https://api.ipify.org?format=json');
+      visitorIP = (await res.json()).ip;
+    } catch {}
+  })();
   const params = new URLSearchParams(window.location.search);
   const slug = params.get('id');
 
@@ -173,26 +180,29 @@
     let currentCount = likeData?.count || 0;
     likeCountEl.textContent = `${currentCount} likes`;
 
-    const likedKey = `liked_${slug}`;
-    if (localStorage.getItem(likedKey)) {
+    const baseKey = `liked_${slug}`;
+    const likedKey = visitorIP ? `${baseKey}_${visitorIP}` : baseKey;
+    if (localStorage.getItem(baseKey) || localStorage.getItem(likedKey)) {
       likeBtn.disabled = true;
       likeBtn.textContent = '❤️ Liked';
+      likeBtn.title = 'Liked ❤️';
     }
 
     likeBtn.addEventListener('click', async () => {
-      if (localStorage.getItem(likedKey)) return;
+      if (localStorage.getItem(baseKey) || localStorage.getItem(likedKey)) return;
 
       const { error: updateError } = await supabase
         .from('likes')
-        .update({ count: currentCount + 1 })
-        .eq('slug', slug);
+        .upsert({ slug, count: currentCount + 1 }, { onConflict: 'slug' });
 
       if (!updateError) {
         currentCount++;
         likeCountEl.textContent = `${currentCount} likes`;
         likeBtn.disabled = true;
         likeBtn.textContent = '❤️ Liked';
-        localStorage.setItem(likedKey, '1');
+        likeBtn.title = 'Liked ❤️';
+        localStorage.setItem(baseKey, '1');
+        if (visitorIP) localStorage.setItem(likedKey, '1');
       } else {
         alert('Something went wrong.');
       }

--- a/gallery.html
+++ b/gallery.html
@@ -57,7 +57,11 @@
         <option value="blogs">Blogs</option>
         <option value="books">Books</option>
       </select>
-      <label class="shuffle-toggle"><input type="checkbox" id="shuffle-toggle"> Shuffle</label>
+        <select id="sort-order">
+          <option value="newest">Newest First</option>
+          <option value="likes">Most Liked</option>
+          <option value="random">Random</option>
+        </select>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Summary
- add sort dropdown to gallery
- fetch visitor IP and store for likes
- display like counts per item and allow liking
- use Supabase upsert for likes
- sort gallery data based on selection

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_684148d30d888322b1ebc1d02590b7c5