### PR TITLE
Enable link submissions & UI tweaks

### DIFF
--- a/index-ar.html
+++ b/index-ar.html
@@ -62,17 +62,17 @@
     <h2>قصص نجاح</h2>
     <div class="story-carousel">
       <a class="story-card" href="story1-ar.html">
-        <img src="images/success/laila-work.png" alt="لقطة من فيلم ليلى القصير">
+        <img loading="lazy" src="images/success/laila-work.png" alt="لقطة من فيلم ليلى القصير">
         <h3>فيلم ليلى</h3>
         <p>باستخدام Stable Diffusion وRunway.</p>
       </a>
       <a class="story-card" href="story2-ar.html">
-        <img src="images/success/rami-work.png" alt="رامي يعمل على مقطوعة موسيقية بالذكاء الاصطناعي">
+        <img loading="lazy" src="images/success/rami-work.png" alt="رامي يعمل على مقطوعة موسيقية بالذكاء الاصطناعي">
         <h3>مقطوعة رامي</h3>
         <p>تأليف AI في Ableton.</p>
       </a>
       <a class="story-card" href="story3-ar.html">
-        <img src="images/gallery/gallery-art.png" alt="عمل فني">
+        <img loading="lazy" src="images/gallery/gallery-art.png" alt="عمل فني">
         <h3>مشروع ملهم آخر</h3>
         <p>استكشاف تقنيات الذكاء الاصطناعي.</p>
       </a>
@@ -83,9 +83,10 @@
     <h2>شارك عملك</h2>
     <p class="helper-note">🔗 نصيحة: فعّل خيار “أي شخص لديه الرابط” في Google Drive.</p>
     <form id="ai-submit-form-ar" action="https://formspree.io/f/xrbpvebk" method="POST">
-      <label>الاسم <input name="fullName" required></label>
-      <label>نوع العمل
-        <select name="workType" required>
+      <label for="fullName-ar">الاسم</label>
+      <input id="fullName-ar" name="fullName" required>
+      <label for="workType-ar">نوع العمل</label>
+        <select id="workType-ar" name="workType" required>
           <option>صورة</option>
           <option>موسيقى</option>
           <option>فيديو</option>
@@ -94,21 +95,20 @@
           <option>كتاب</option>
           <option>بودكاست</option>
         </select>
-      </label>
-      <label>
-        Upload file (image/video/audio):
-        <input type="file" name="workFile" accept="image/*,video/*,audio/*">
-      </label>
-      <label>وصف
-        <textarea name="description" rows="3" maxlength="500" required></textarea>
+      <label for="workFile-ar">Upload file (image/video/audio):</label>
+      <input id="workFile-ar" type="file" name="workFile" accept="image/*,video/*,audio/*">
+      <label for="upload-link-ar">أو الصق رابطاً</label>
+      <input type="url" id="upload-link-ar" name="workLink" placeholder="https://youtu.be/…" pattern="https?://.+" autocomplete="off">
+      <label for="description-ar">وصف</label>
+        <textarea id="description-ar" name="description" rows="3" maxlength="500" required></textarea>
         <div class="char-count">0/500</div>
-      </label>
-      <button class="cta-btn">إرسال</button>
+      <progress class="upload-progress" max="100" value="0" style="display:none"></progress>
+      <button class="cta-btn btn-primary" type="submit">إرسال</button>
     </form>
 
     <div id="thank-you-modal-ar" class="thank-you-modal">
       <div class="modal-content">
-        <span id="close-modal-btn-ar" class="modal-close">&times;</span>
+        <button id="close-modal-btn-ar" class="modal-close" aria-label="Close">&times;</button>
         <h3>شكراً لك!</h3>
         <p>تم استلام مشاركتك.</p>
       </div>

--- a/index.html
+++ b/index.html
@@ -65,17 +65,17 @@
     <h2>Success Stories</h2>
     <div class="story-carousel">
       <a class="story-card" href="story1.html">
-        <img src="images/success/laila-work.png" alt="Still from Laila's animated short film">
+        <img loading="lazy" src="images/success/laila-work.png" alt="Still from Laila's animated short film">
         <h3>Laila’s animated short</h3>
         <p>Created with Stable Diffusion & Runway.</p>
       </a>
       <a class="story-card" href="story2.html">
-        <img src="images/success/rami-work.png" alt="Rami creating music with AI tools">
+        <img loading="lazy" src="images/success/rami-work.png" alt="Rami creating music with AI tools">
         <h3>Rami’s generative track</h3>
         <p>AI‑assisted composition in Ableton.</p>
       </a>
       <a class="story-card" href="story3.html">
-        <img src="images/gallery/gallery-art.png" alt="Placeholder art">
+        <img loading="lazy" src="images/gallery/gallery-art.png" alt="Placeholder art">
         <h3>Another inspiring project</h3>
         <p>Exploring creative AI techniques.</p>
       </a>
@@ -86,9 +86,10 @@
     <h2>Submit your work</h2>
     <p class="helper-note">🔗 Tip: If using Google Drive, set sharing to “Anyone with the link”.</p>
     <form id="ai-submit-form" action="https://formspree.io/f/xrbpvebk" method="POST">
-      <label>Name <input name="fullName" required></label>
-      <label>Type
-        <select name="workType" required>
+      <label for="fullName">Name</label>
+      <input id="fullName" name="fullName" required>
+      <label for="workType">Type</label>
+        <select id="workType" name="workType" required>
           <option>Image</option>
           <option>Music</option>
           <option>Video</option>
@@ -97,20 +98,19 @@
           <option>Book</option>
           <option>Podcast</option>
         </select>
-      </label>
-      <label>
-        Upload file (image/video/audio):
-        <input type="file" name="workFile" accept="image/*,video/*,audio/*">
-      </label>
-      <label>Description
-        <textarea name="description" rows="3" maxlength="500" required></textarea>
+      <label for="workFile">Upload file (image/video/audio):</label>
+      <input id="workFile" type="file" name="workFile" accept="image/*,video/*,audio/*">
+      <label for="upload-link">or paste a link</label>
+      <input type="url" id="upload-link" name="workLink" placeholder="https://youtu.be/…" pattern="https?://.+" autocomplete="off">
+      <label for="description">Description</label>
+        <textarea id="description" name="description" rows="3" maxlength="500" required></textarea>
         <div class="char-count">0/500</div>
-      </label>
-      <button class="cta-btn">Send</button>
+      <progress class="upload-progress" max="100" value="0" style="display:none"></progress>
+      <button class="cta-btn btn-primary" type="submit">Send</button>
     </form>
     <div id="thank-you-modal" class="thank-you-modal">
       <div class="modal-content">
-        <span id="close-modal-btn" class="modal-close">&times;</span>
+        <button id="close-modal-btn" class="modal-close" aria-label="Close">&times;</button>
         <h3>Thank you!</h3>
         <p>Your submission was received.</p>
       </div>

--- a/js/gallery.js
+++ b/js/gallery.js
@@ -38,6 +38,13 @@ let sortOrder = 'newest';
 let likeCounts = {};
 const params = new URLSearchParams(window.location.search);
 const creatorParam = (params.get('creator') || '').toLowerCase();
+
+function getFallbackThumb(link) {
+  if (!link) return '';
+  const yt = link.match(/(?:youtu\.be\/|youtube\.com\/(?:watch\?v=|embed\/|v\/))([\w-]{11})/);
+  if (yt) return `https://img.youtube.com/vi/${yt[1]}/hqdefault.jpg`;
+  return '/assets/icons/link.svg';
+}
 const isArabic = document.documentElement.lang === 'ar';
 
 function createShareButtons(url, text) {
@@ -210,7 +217,7 @@ function renderFiltered(reset = false) {
     if (!container) return;
     hasData[section] = true;
 
-    const imgSrc = item.type === 'image' ? item.link : item.thumb || '';
+    const imgSrc = item.type === 'image' ? item.link : item.thumb || getFallbackThumb(item.link);
     const card = document.createElement('div');
     card.className = 'gallery-card show';
     card.dataset.id = item.id;

--- a/js/main.js
+++ b/js/main.js
@@ -6,6 +6,17 @@ document.addEventListener('DOMContentLoaded', () => {
     btn.addEventListener('click', () => links.classList.toggle('open'));
   }
 
+  const navbar = document.querySelector('.navbar');
+  if (navbar) {
+    window.addEventListener('scroll', () => {
+      if (window.scrollY > 10) {
+        navbar.classList.add('shadow');
+      } else {
+        navbar.classList.remove('shadow');
+      }
+    });
+  }
+
   // Contact forms submission via Formspree
   const forms = [
     { id: 'contact-form', ar: false },

--- a/js/submit.js
+++ b/js/submit.js
@@ -13,13 +13,22 @@ supabase.auth.onAuthStateChange((_event, session) => {
 function initSubmitForms() {
   const form = document.querySelector('#ai-submit-form, #ai-submit-form-ar');
   if (!form) return;
+  const progress = form.querySelector('progress');
+  const submitBtn = form.querySelector('button[type="submit"]');
 
   form.addEventListener('submit', async (e) => {
     e.preventDefault();
     const lang = document.documentElement.lang === 'ar' ? 'ar' : 'en';
 
     const fileInput = form.workFile;
+    const linkEl = form.workLink;
     let uploadedURL = '';
+
+    if (submitBtn) submitBtn.disabled = true;
+    if (progress) {
+      progress.value = 0;
+      progress.style.display = 'block';
+    }
 
     if (fileInput && fileInput.files.length > 0) {
       const file = fileInput.files[0];
@@ -30,6 +39,8 @@ function initSubmitForms() {
 
       if (uploadError) {
         alert(lang === 'ar' ? 'فشل رفع الملف' : 'File upload failed');
+        if (submitBtn) submitBtn.disabled = false;
+        if (progress) progress.style.display = 'none';
         return;
       }
 
@@ -38,11 +49,13 @@ function initSubmitForms() {
         .getPublicUrl(filePath);
       uploadedURL = publicURL.publicUrl;
     }
+    if (progress) progress.value = 100;
 
+    const linkVal = linkEl ? linkEl.value.trim() : '';
     const data = {
       creator_name: form.fullName.value,
       type: form.workType.value.toLowerCase(),
-      link: uploadedURL || form.workLink?.value || '',
+      link: uploadedURL || linkVal || '',
       title_en: lang === 'en' ? form.description.value : '',
       title_ar: lang === 'ar' ? form.description.value : '',
       desc_en: lang === 'en' ? form.description.value : '',
@@ -55,19 +68,38 @@ function initSubmitForms() {
     if (error) {
       alert(lang === 'ar' ? 'فشل الإرسال. حاول مجددًا.' : 'Submission failed. Please try again.');
       console.error(error);
+      if (submitBtn) submitBtn.disabled = false;
+      if (progress) progress.style.display = 'none';
       return;
     }
 
+    alert(lang === 'ar' ? 'شكراً! تم استلام مشاركتك.' : 'Thanks! Your submission was received.');
+
     const modalId = lang === 'ar' ? 'thank-you-modal-ar' : 'thank-you-modal';
     const modal = document.getElementById(modalId);
-    if (modal) modal.style.display = 'block';
+    if (modal) {
+      modal.style.display = 'block';
+      setTimeout(() => { modal.style.display = 'none'; }, 4000);
+      const esc = (ev) => {
+        if (ev.key === 'Escape') {
+          modal.style.display = 'none';
+          document.removeEventListener('keydown', esc);
+        }
+      };
+      document.addEventListener('keydown', esc);
+    }
     form.reset();
 
     const closeBtnId = lang === 'ar' ? 'close-modal-btn-ar' : 'close-modal-btn';
     const closeBtn = document.getElementById(closeBtnId);
     if (closeBtn) {
-      closeBtn.onclick = () => { modal.style.display = 'none'; };
+      closeBtn.onclick = () => {
+        if (modal) modal.style.display = 'none';
+      };
     }
+
+    if (submitBtn) submitBtn.disabled = false;
+    if (progress) progress.style.display = 'none';
   });
 }
 

--- a/styles/main.css
+++ b/styles/main.css
@@ -28,6 +28,7 @@ main section{padding-block:var(--section-space)}
 /* NAVBAR */
 .navbar{position:sticky;top:0;z-index:999;border-bottom:1px solid rgba(255,255,255,.08)}
 .navbar-dark{background:rgba(17,17,17,.9);backdrop-filter:blur(10px)}
+.navbar.shadow{box-shadow:0 2px 6px rgba(0,0,0,.5);backdrop-filter:blur(4px)}
 .navbar-container{display:flex;align-items:center;justify-content:space-between;padding:.5rem 1rem}
 .logo{font-weight:700;font-size:1.2rem}
 .navbar-links{display:flex;gap:1rem}
@@ -61,7 +62,7 @@ main section{padding-block:var(--section-space)}
 
 /* SUCCESS STORIES */
 .success-stories h2{text-align:center}
-.story-carousel{display:flex;gap:1.5rem;margin-top:2rem;overflow:hidden;scroll-snap-type:x mandatory;}
+.story-carousel{display:flex;gap:1.5rem;margin-top:2rem;overflow:hidden;scroll-snap-type:x mandatory;max-width:960px;margin-inline:auto;}
 .story-card{background:rgba(255,255,255,0.05);backdrop-filter:blur(10px);border-radius:var(--radius);box-shadow:var(--shadow);overflow:hidden;transition:var(--transition);min-width:100%;scroll-snap-align:center}
 .story-card img{width:100%;height:200px;object-fit:cover}
 .story-card:hover{transform:translateY(-4px);box-shadow:0 0 15px var(--accent)}
@@ -291,3 +292,5 @@ html[dir="rtl"] .creator-socials a{
   margin-bottom: 1.2rem;
   font-size: 1.1rem;
 }
+
+.btn-primary:disabled{opacity:.4;cursor:not-allowed}


### PR DESCRIPTION
## Summary
- add lazy loading and centered width to success stories carousel
- allow submitting a link in addition to uploading a file
- provide accessible modal close button and upload progress bar
- handle link-only submissions in JS and show toast + auto-close
- add navbar shadow blur and disabled button style
- fallback thumbnails for link items
- mirror features in Arabic page

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68448f76d9f88322b45b4e6fc659ae64