### PR TITLE
Patch un-blocking dialog + comments UX

### DIFF
--- a/js/comments.js
+++ b/js/comments.js
@@ -23,12 +23,20 @@ export async function mountComments(wrapper, submissionId){
       .select('name,body,created_at')
       .eq('submission_id', submissionId)
       .order('created_at','asc');
-    listEl.innerHTML = (data||[]).map(c=>`
+
+    if(!data || data.length===0){
+      listEl.innerHTML = '<em style="color:#777">No comments yet…</em>';
+      return;
+    }
+
+    listEl.innerHTML = data.map(c=>`
       <div class="c-item">
         <strong>${c.name}</strong>
         <small>${new Date(c.created_at).toLocaleString()}</small>
         <p>${c.body}</p>
       </div>`).join('');
+    /* scroll to newest */
+    listEl.scrollTop = listEl.scrollHeight;
   }
 
   formEl.addEventListener('submit', async e=>{

--- a/styles/gallery.css
+++ b/styles/gallery.css
@@ -32,20 +32,22 @@
 .controls{margin-top:1.5rem}
 .card .inner{padding:8px}
 .card img{height:200px;object-fit:cover;width:100%}
-/* centered modal */
+/* dialog – hidden when not [open] */
 #previewModal{
-  padding:0;
-  border:none;
-  background:transparent;
-  width:100vw;
-  max-width:100vw;
-  height:100vh;
-  display:flex;
-  align-items:center;
-  justify-content:center;
+  display:none;                     /* default (closed) */
+  position:fixed;inset:0;
+  padding:0;border:none;background:transparent;
+  align-items:center;justify-content:center;
 }
-#previewModal::backdrop{background:rgba(0,0,0,.8)}
-.modal-media{max-width:90vw;max-height:80vh;object-fit:contain}
+#previewModal[open]{               /* only when open attribute exists */
+  display:flex;
+}
+#previewModal::backdrop{
+  background:rgba(0,0,0,.8);
+}
+.modal-media{
+  max-width:90vw;max-height:80vh;object-fit:contain
+}
 #previewModal .like-btn{margin-top:10px}
 .close-btn{
   position:absolute;top:6px;right:10px;font-size:24px;
@@ -66,27 +68,19 @@
 
 /* comments UI */
 #comments h4{margin:8px 0 4px}
-.c-list{max-height:28vh;overflow-y:auto;margin-bottom:6px}
+.c-list{max-height:26vh;overflow-y:auto;margin-bottom:6px}
 .c-item{background:#222;padding:6px;border-radius:6px;margin-bottom:4px}
 #comments textarea,#comments input{width:100%;margin-bottom:4px}
 #comments button{background:#3b7d4a;color:#fff;border:none;padding:4px 12px;border-radius:4px;cursor:pointer;font-size:.85rem}
-/* centred modal */
-#previewModal{
-  padding:0;border:none;background:transparent;
-  width:100vw;height:100vh;
-  display:flex;align-items:center;justify-content:center;
-}
-#previewModal::backdrop{background:rgba(0,0,0,.8)}
-.modal-media{max-width:90vw;max-height:80vh;object-fit:contain}
-#previewModal .like-btn{margin-top:10px}
+
 
 /* comments panel */
 #comments{
-  margin-top:12px;background:#191919;padding:10px;border-radius:8px;
+  margin-top:14px;background:#191919;padding:10px;border-radius:8px;
   width:100%;max-width:640px;box-shadow:0 0 6px rgba(0,0,0,.6);font-size:.9rem;
 }
 #comments h4{margin:0 0 8px;font-size:1rem;color:#f1f1f1}
-.c-list{max-height:28vh;overflow-y:auto;margin-bottom:8px;padding-right:4px}
+.c-list{max-height:26vh;overflow-y:auto;margin-bottom:8px;padding-right:4px}
 .c-item{background:#262626;padding:6px 8px;border-radius:6px;margin-bottom:6px}
 .c-item strong{color:#3b7d4a}.c-item small{color:#888;margin-left:4px;font-size:.7rem}
 #comments form{display:flex;flex-direction:column;gap:6px}


### PR DESCRIPTION
## Summary
- update gallery modal to open/close via `[open]` attribute
- adjust comments panel margins and list height
- show message when no comments and auto-scroll to newest

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6845af89da508322b41d5bb3d2b51881