### PR TITLE
Fix gallery load filter

### DIFF
--- a/js/gallery.js
+++ b/js/gallery.js
@@ -23,7 +23,7 @@ async function fetchData(){
   const { data, error } = await supabase
     .from('submissions')
     .select('*')
-    .eq('status','approved')
+    .in('status', ['approved','published','ready'])
     .range(currentPage*PAGE_SIZE, currentPage*PAGE_SIZE + PAGE_SIZE - 1)
     .order('created_at',{ascending:false});
 


### PR DESCRIPTION
## Summary
- allow gallery to load posts from any published status

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6846edf794c8832289ce3093bb7d4f1a