### PR TITLE
Use thumbnails in gallery previews

### DIFF
--- a/js/gallery.js
+++ b/js/gallery.js
@@ -35,7 +35,7 @@ function createCard (it) {
   el.className = 'gallery-card';
 
   const img = document.createElement('img');
-  img.src   = it.link;
+  img.src   = it.thumb || it.link;
   img.alt   = it.title_en || 'Artwork';
   img.loading = 'lazy';
   img.onload = () => { el.style.minHeight = 'unset'; };
@@ -47,7 +47,7 @@ function createCard (it) {
 
 function openModal (it) {
   modalC.innerHTML = `
-    <img src="${it.link}" class="modal-media" alt="">
+    <img src="${it.thumb || it.link}" class="modal-media" alt="">
     <button id="likeBtn" class="like-btn">🔥 <span>${it.likes}</span></button>
     <div id="cWrap"></div>`;
   mountComments(modalC.querySelector('#cWrap'), it.id);


### PR DESCRIPTION
## Summary
- prefer `thumb` over `link` when populating gallery cards
- update modal preview to also prefer the thumbnail when present

## Testing
- `node --check js/gallery.js`
- `node test.js` *(temporary, removed)*

------
https://chatgpt.com/codex/tasks/task_e_685025c13a2c8322aa44d9095aabcb86