### PR TITLE
Phase 8-A – restore env & gallery base

### DIFF
--- a/js/env.js
+++ b/js/env.js
@@ -1,0 +1,3 @@
+const SUPABASE_URL = 'https://mclcwqoecszpctglwwxz.supabase.co';
+const SUPABASE_ANON_KEY =
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Im1jbGN3cW9lY3N6cGN0Z2x3d3h6Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDU5NTI2MDUsImV4cCI6MjA2MTUyODYwNX0.LuAyKXuDmt9afXzy-jaAtdMUKEOx0woxr5dTs0Yd0cs';

--- a/js/gallery.js
+++ b/js/gallery.js
@@ -1,0 +1,30 @@
+import { createClient } from 'https://cdn.jsdelivr.net/npm/@supabase/supabase-js/+esm';
+const supabase = createClient(window.SUPABASE_URL, window.SUPABASE_ANON_KEY);
+const sections = ['image','music','video','blog','book']; let all=[];
+async function load(){
+  const {data} = await supabase.from('submissions').select('*').eq('status','approved');
+  all=data||[]; render();
+}
+function render(){
+  const q=document.getElementById('search-input')?.value?.toLowerCase()||'';
+  const t=document.getElementById('type-filter')?.value||'';
+  sections.forEach(s=>{
+    const c=document.querySelector('#'+s+' .gallery-grid'); if(!c)return; c.innerHTML='';
+    all.filter(it=>{
+      const mT=t?it.type===t:true;
+      const mS=(it.title_en||it.title_ar||'').toLowerCase().includes(q)||
+               (it.creator_name||'').toLowerCase().includes(q);
+      return it.type===s && mT && mS;
+    }).forEach(it=>{
+      const card=document.createElement('div'); card.className='gallery-card show';
+      card.innerHTML=`<img src="${it.type==='image'?it.link:''}" alt="">
+        <div class="gallery-meta">By <b>${it.creator_name||'-'}</b></div>
+        <div class="gallery-title">${it.title_en||it.title_ar||''}</div>`;
+      c.appendChild(card);
+    });
+  });
+}
+document.addEventListener('DOMContentLoaded',()=>{load();
+  document.getElementById('search-input')?.addEventListener('input',render);
+  document.getElementById('type-filter')?.addEventListener('change',render);
+});

--- a/styles/gallery.css
+++ b/styles/gallery.css
@@ -1,0 +1,4 @@
+.gallery-card{background:#fff;border-radius:12px;box-shadow:0 4px 12px rgba(0,0,0,.08);
+  padding:16px;opacity:0;transform:translateY(20px);transition:.4s}
+.gallery-card.show{opacity:1;transform:none}
+.gallery-card img{width:100%;max-height:220px;object-fit:cover;border-radius:8px;margin-bottom:12px}


### PR DESCRIPTION
## Summary
- restore `env.js` with Supabase credentials
- add simplified `gallery.js` for listing approved submissions
- style gallery cards with `gallery.css`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6873fe77ba848322b900fe778eea0fd2