### PR TITLE
Hotfix – expose SUPABASE keys on window for gallery/auth

### DIFF
--- a/js/env.js
+++ b/js/env.js
@@ -1,3 +1,5 @@
-const SUPABASE_URL = 'https://mclcwqoecszpctglwwxz.supabase.co';
-const SUPABASE_ANON_KEY =
+/* global Supabase keys – exposed on window for modules */
+window.SUPABASE_URL =
+  'https://mclcwqoecszpctglwwxz.supabase.co';
+window.SUPABASE_ANON_KEY =
   'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6Im1jbGN3cW9lY3N6cGN0Z2x3d3h6Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NDU5NTI2MDUsImV4cCI6MjA2MTUyODYwNX0.LuAyKXuDmt9afXzy-jaAtdMUKEOx0woxr5dTs0Yd0cs';


### PR DESCRIPTION
## Summary
- expose Supabase credentials on the `window` object so modules can access them

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_687405ac947c8322a0fc286e7addea73